### PR TITLE
Visual Studio 2014 support for node v0.10.x series

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -44,7 +44,7 @@
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': 1, # static debug
+            'RuntimeLibrary': 3, # MDd
             'Optimization': 0, # /Od, no optimization
             'MinimalRebuild': 'false',
             'OmitFramePointers': 'false',
@@ -96,7 +96,7 @@
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': 0, # static release
+            'RuntimeLibrary': 2, # MD
             'Optimization': 3, # /Ox, full optimization
             'FavorSizeOrSpeed': 1, # /Ot, favour speed over size
             'InlineFunctionExpansion': 2, # /Ob2, inline anything eligible

--- a/common.gypi
+++ b/common.gypi
@@ -171,7 +171,7 @@
       }],
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', '-pthread', ],
-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
+        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=c++11' ],
         'ldflags': [ '-pthread', '-rdynamic' ],
         'target_conditions': [
           ['_type=="static_library"', {

--- a/common.gypi
+++ b/common.gypi
@@ -198,6 +198,10 @@
       ['OS=="mac"', {
         'defines': ['_DARWIN_USE_64_BIT_INODE=1'],
         'xcode_settings': {
+          'CLANG_CXX_LIBRARY': 'libc++',
+          'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+          'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
+          'GCC_OPTIMIZATION_LEVEL': '3',
           'ALWAYS_SEARCH_USER_PATHS': 'NO',
           'GCC_CW_ASM_SYNTAX': 'NO',                # No -fasm-blocks
           'GCC_DYNAMIC_NO_PIC': 'NO',               # No -mdynamic-no-pic
@@ -207,7 +211,7 @@
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
-          'MACOSX_DEPLOYMENT_TARGET': '10.5',       # -mmacosx-version-min=10.5
+          'MACOSX_DEPLOYMENT_TARGET': '10.9',       # -mmacosx-version-min=10.9
           'USE_HEADERMAP': 'NO',
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',

--- a/configure
+++ b/configure
@@ -655,7 +655,7 @@ def configure_winsdk(o):
 
   winsdk_dir = os.environ.get("WindowsSdkDir")
 
-  if winsdk_dir and os.path.isfile(winsdk_dir + '\\bin\\ctrpp.exe'):
+  if winsdk_dir and os.path.isfile(winsdk_dir + '\\bin\\x64\\ctrpp.exe'):
     print "Found ctrpp in WinSDK--will build generated files into tools/msvs/genfiles."
     o['variables']['node_has_winsdk'] = 'true'
     return
@@ -724,7 +724,7 @@ if options.use_ninja:
 elif options.use_xcode:
   gyp_args += ['-f', 'xcode']
 elif flavor == 'win':
-  gyp_args += ['-f', 'msvs', '-G', 'msvs_version=auto']
+  gyp_args += ['-f', 'msvs', '-G', 'msvs_version=2013']
 else:
   gyp_args += ['-f', 'make-' + flavor]
 

--- a/deps/cares/common.gypi
+++ b/deps/cares/common.gypi
@@ -18,9 +18,9 @@
           'VCCLCompilerTool': {
             'target_conditions': [
               ['library=="static_library"', {
-                'RuntimeLibrary': 1 # static debug
+                'RuntimeLibrary': 3 # MDd
               }, {
-                'RuntimeLibrary': 3 # DLL debug
+                'RuntimeLibrary': 3 # MDd
               }]
             ],
             'Optimization': 0, # /Od, no optimization
@@ -49,9 +49,9 @@
           'VCCLCompilerTool': {
             'target_conditions': [
               ['library=="static_library"', {
-                'RuntimeLibrary': 0, # static release
+                'RuntimeLibrary': 2 # MD
               }, {
-                'RuntimeLibrary': 2, # debug release
+                'RuntimeLibrary': 2 # MD
               }],
             ],
             'Optimization': 3, # /Ox, full optimization

--- a/deps/http_parser/http_parser.gyp
+++ b/deps/http_parser/http_parser.gyp
@@ -14,7 +14,7 @@
         'defines': [ 'DEBUG', '_DEBUG' ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': 1, # static debug
+            'RuntimeLibrary': 3 # MDd
           },
         },
       },
@@ -22,7 +22,7 @@
         'defines': [ 'NDEBUG' ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': 0, # static release
+            'RuntimeLibrary': 2 # MD
           },
         },
       }

--- a/deps/openssl/openssl/e_os.h
+++ b/deps/openssl/openssl/e_os.h
@@ -307,7 +307,7 @@ static unsigned int _strlen31(const char *str)
 #      undef isxdigit
 #    endif
 #    if defined(_MSC_VER) && !defined(_DLL) && defined(stdin)
-#      if _MSC_VER>=1300
+#      if _MSC_VER>=1300 && _MSC_VER<1900
 #        undef stdin
 #        undef stdout
 #        undef stderr
@@ -315,7 +315,7 @@ static unsigned int _strlen31(const char *str)
 #        define stdin  (&__iob_func()[0])
 #        define stdout (&__iob_func()[1])
 #        define stderr (&__iob_func()[2])
-#      elif defined(I_CAN_LIVE_WITH_LNK4049)
+#      elif _MSC_VER<1900 && defined(I_CAN_LIVE_WITH_LNK4049)
 #        undef stdin
 #        undef stdout
 #        undef stderr

--- a/deps/uv/common.gypi
+++ b/deps/uv/common.gypi
@@ -20,9 +20,9 @@
           'VCCLCompilerTool': {
             'target_conditions': [
               ['library=="static_library"', {
-                'RuntimeLibrary': 1, # static debug
+                'RuntimeLibrary': 3 # MDd
               }, {
-                'RuntimeLibrary': 3, # DLL debug
+                'RuntimeLibrary': 3 # MDd
               }],
             ],
             'Optimization': 0, # /Od, no optimization
@@ -57,9 +57,9 @@
           'VCCLCompilerTool': {
             'target_conditions': [
               ['library=="static_library"', {
-                'RuntimeLibrary': 0, # static release
+                'RuntimeLibrary': 2 # MD
               }, {
-                'RuntimeLibrary': 2, # debug release
+                'RuntimeLibrary': 2 # MD
               }],
             ],
             'Optimization': 3, # /Ox, full optimization

--- a/deps/uv/src/win/fs.c
+++ b/deps/uv/src/win/fs.c
@@ -732,9 +732,9 @@ void fs__readdir(uv_fs_t* req) {
   if (len == 0) {
     fmt = L"./*";
   } else if (pathw[len - 1] == L'/' || pathw[len - 1] == L'\\') {
-    fmt = L"%s*";
+    fmt = L"%S*";
   } else {
-    fmt = L"%s\\*";
+    fmt = L"%S\\*";
   }
 
   /* Figure out whether path is a file or a directory. */

--- a/deps/v8/build/common.gypi
+++ b/deps/v8/build/common.gypi
@@ -344,9 +344,9 @@
 
             'conditions': [
               ['OS=="win" and component=="shared_library"', {
-                'RuntimeLibrary': '3',  # /MDd
+                'RuntimeLibrary': 3 # MDd
               }, {
-                'RuntimeLibrary': '1',  # /MTd
+                'RuntimeLibrary': 3 # MDd
               }],
             ],
           },
@@ -409,9 +409,9 @@
                 'StringPooling': 'true',
                 'conditions': [
                   ['OS=="win" and component=="shared_library"', {
-                    'RuntimeLibrary': '2',  #/MD
+                    'RuntimeLibrary': 2 # MD
                   }, {
-                    'RuntimeLibrary': '0',  #/MT
+                    'RuntimeLibrary': 2 # MD
                   }],
                   ['v8_target_arch=="x64"', {
                     # TODO(2207): remove this option once the bug is fixed.

--- a/deps/zlib/zconf.h
+++ b/deps/zlib/zconf.h
@@ -113,6 +113,9 @@
 #endif
 #if !defined(STDC) && (defined(MSDOS) || defined(WINDOWS) || defined(WIN32))
 #  define STDC
+#if _MSC_VER>=1900
+#  define STDC99
+#endif
 #endif
 #if !defined(STDC) && (defined(OS2) || defined(__HOS_AIX__))
 #  define STDC

--- a/src/node.cc
+++ b/src/node.cc
@@ -2071,7 +2071,7 @@ static Handle<Value> EnvSetter(Local<String> property,
   WCHAR* key_ptr = reinterpret_cast<WCHAR*>(*key);
   // Environment variables that start with '=' are read-only.
   if (key_ptr[0] != L'=') {
-    SetEnvironmentVariableW(key_ptr, reinterpret_cast<WCHAR*>(*val));
+    _wputenv_s(key_ptr, reinterpret_cast<WCHAR*>(*val));
   }
 #endif
   // Whether it worked or not, always return rval.

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -99,6 +99,15 @@ ENDLOCAL
 @rem Skip project generation if requested.
 if defined nobuild goto sign
 
+@rem Look for Visual Studio 2014
+if not defined VS140COMNTOOLS goto vc-set-2013
+if not exist "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2013
+call "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat"
+if not defined VCINSTALLDIR goto msbuild-not-found
+set GYP_MSVS_VERSION=2013
+goto msbuild-found
+
+:vc-set-2013
 @rem Look for Visual Studio 2013
 if not defined VS120COMNTOOLS goto vc-set-2012
 if not exist "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2012
@@ -129,7 +138,7 @@ goto run
 
 :msbuild-found
 @rem Build the sln with msbuild.
-msbuild node.sln /m /t:%target% /p:Configuration=%config% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
+msbuild node.sln /m:%NUMBER_OF_PROCESSORS% /p:BuildInParallel=true /toolsversion:14.0 /p:PlatformToolset=v140 /t:%target% /p:Configuration=%config% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 
 :sign

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -13,6 +13,7 @@ if /i "%1"=="/?" goto help
 
 @rem Process arguments.
 set config=Release
+set platform=Win32
 set msiplatform=x86
 set target=Build
 set target_arch=ia32
@@ -76,6 +77,7 @@ if defined jslint goto jslint
 
 if "%config%"=="Debug" set debug_arg=--debug
 if "%target_arch%"=="x64" set msiplatform=x64
+if "%target_arch%"=="x64" set platform=x64
 if defined nosnapshot set nosnapshot_arg=--without-snapshot
 if defined noetw set noetw_arg=--without-etw& set noetw_msi_arg=/p:NoETW=1
 if defined noperfctr set noperfctr_arg=--without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
@@ -138,7 +140,7 @@ goto run
 
 :msbuild-found
 @rem Build the sln with msbuild.
-msbuild node.sln /m:%NUMBER_OF_PROCESSORS% /p:BuildInParallel=true /toolsversion:14.0 /p:PlatformToolset=v140 /t:%target% /p:Configuration=%config% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
+msbuild node.sln /m:%NUMBER_OF_PROCESSORS% /p:BuildInParallel=true /toolsversion:14.0 /p:PlatformToolset=v140 /t:%target% /p:Configuration=%config% /p:Platform=%platform% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 
 :sign
@@ -205,7 +207,7 @@ if "%test%"=="test" goto jslint
 goto exit
 
 :create-msvs-files-failed
-echo Failed to create vc project files. 
+echo Failed to create vc project files.
 goto exit
 
 :upload


### PR DESCRIPTION
Work in progress to get node v0.10.x working against Visual Studio 2014
- [x] figure out what changed with getenv/setenv behavior with 2014 runtimes (https://github.com/mapbox/node-srs/issues/48)
- [ ] try to get gyp 2014 patch accepted upstream - https://code.google.com/p/gyp/issues/detail?id=446&q=2014
